### PR TITLE
WIP: Support for generating iPad Playgrounds

### DIFF
--- a/lib/cocoapods-playgrounds/command/playgrounds.rb
+++ b/lib/cocoapods-playgrounds/command/playgrounds.rb
@@ -70,8 +70,8 @@ module Pod
           FileUtils.rm_rf(pods)
 
           File.open("#{name}Playground/#{name}.playground/Contents.swift", 'w') do |f|
-            f.write("import XCPlayground\n")
-            f.write("XCPlaygroundPage.currentPage.needsIndefiniteExecution = true\n\n")
+            f.write("import PlaygroundSupport\n")
+            f.write("PlaygroundPage.current.needsIndefiniteExecution = true\n\n")
           end
         end
       end

--- a/lib/cocoapods-playgrounds/command/playgrounds.rb
+++ b/lib/cocoapods-playgrounds/command/playgrounds.rb
@@ -82,7 +82,8 @@ module Pod
       def migrate(input, output)
         xcode_path = `xcode-select -p`.strip
         sdk_path = "#{xcode_path}/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk"
-        `xcrun swift-update -sdk #{sdk_path} -target arm64-apple-ios9 #{input} >#{output}`
+        `xcrun swift-update -sdk '#{sdk_path}' -target arm64-apple-ios9 #{input} >#{output}`
+        FileUtils.cp(input, output) if $?.exitstatus != 0
       end
     end
   end

--- a/lib/cocoapods-playgrounds/workspace.rb
+++ b/lib/cocoapods-playgrounds/workspace.rb
@@ -15,7 +15,7 @@ module Pod
       @tool = tool
     end
 
-    def generate(install = true)
+    def generate(install = true, open = true)
       @cwd = Pathname.getwd
       `rm -fr '#{target_dir}'`
       FileUtils.mkdir_p(target_dir)
@@ -28,7 +28,8 @@ module Pod
         generate_swift_code(path)
       end
 
-      `open #{workspace_path}` if install
+      `open #{workspace_path}` if install && open
+      names.first
     end
 
     private


### PR DESCRIPTION
This adds a new `--ipad` option to the `pod playgrounds` command, which copies the source files from all used Pods to the `Sources` directory inside the Playground, with the goal of creating a Playground with third-party code usable on iPad. By default, it will also run the migrator, as it is expected that most Pods do not support Swift 3 just yet.

Thanks to @NachoSoto and [@orta](https://github.com/orta/life/issues/76) for coming up with the idea independently :)
### Known Issues
- Needs to eliminate `import` statements when dependencies are being used, because we will have all the code in a single clang module.
- This is currently not really feasible because of the Swift version being used in iPad Playgrounds is not the same as the one being used by Xcode 8:

![](https://pbs.twimg.com/media/ClkjfCBWMAE8wyD.jpg)
