### PR TITLE
Add support for legacy Xcode versions

### DIFF
--- a/lib/cocoapods-playgrounds/command/playgrounds.rb
+++ b/lib/cocoapods-playgrounds/command/playgrounds.rb
@@ -32,6 +32,7 @@ module Pod
         @install = argv.flag?('install', true)
         @platform = argv.option('platform', DEFAULT_PLATFORM_NAME).to_sym
         @platform_version = argv.option('platform_version', Playgrounds.default_version_for_platform(@platform))
+        @use_legacy_xcode = is_legacy_xcode?
         super
       end
 
@@ -40,9 +41,13 @@ module Pod
         help! 'At least one Pod name is required.' unless @names
       end
 
+      def is_legacy_xcode?
+        %x( xcodebuild -version ).include? "Xcode 7"
+      end
+
       def run
         # TODO: Pass platform and deployment target from configuration
-        generator = WorkspaceGenerator.new(@names, :cocoapods, @platform, @platform_version)
+        generator = WorkspaceGenerator.new(@names, :cocoapods, @platform, @platform_version, @use_legacy_xcode)
         generator.generate(@install)
       end
     end


### PR DESCRIPTION
This commit is largely based on (https://github.com/segiddins/ThisCouldBeUsButYouPlaying/pull/44) by @askielboe to get support for Xcode 8.

What's included in this pull request 

- Support for legacy Xcode 
-- Invoke xcodebuild to figure out the current Xcode version
-- Generate the playgrounds based on this additional parameter

- Fixes an issue with the generated path